### PR TITLE
feat: Implement Clone for OwnedBatchInsert

### DIFF
--- a/diesel/src/insertable.rs
+++ b/diesel/src/insertable.rs
@@ -293,7 +293,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OwnedBatchInsert<V, Tab> {
     pub(crate) values: Vec<V>,
     _marker: PhantomData<Tab>,


### PR DESCRIPTION
This allows to clone queries that insert a vector of records (useful when you want to implement a retriable query).

P.S. Before this fix, I can clone a query which inserts a single value, but unable to clone a query when I insert a vec of values.